### PR TITLE
Update Middleware.php

### DIFF
--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -61,6 +61,11 @@ class Middleware implements MiddlewareInterface
                     }
                     try {
                         Redis::connection($key)->listen(function (CommandExecuted $command) {
+                            foreach ($command->parameters as &$item) {
+                                if (is_array($item)) {
+                                    $item = implode('\', \'', $item);
+                                }
+                            }
                             $this->logs .= "[Redis]\t[connection:{$command->connectionName}] Redis::{$command->command}('" . implode('\', \'', $command->parameters) . "') ({$command->time} ms)" . PHP_EOL;
                         });
                     } catch (\Throwable $e) {}


### PR DESCRIPTION
记录 Redis 命令日志时，$command->parameters 有可能是多维数组，此时会报错。
例如这个命令：Redis::set($key, $val, 'EX', $expired);